### PR TITLE
Bump to sportbukkit 1.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>tc.oc</groupId>
             <artifactId>sportbukkit-api</artifactId>
-            <version>1.9.2-R0.1-SNAPSHOT</version>
+            <version>1.11.1-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>


### PR DESCRIPTION
Use sportbukkit 1.11.1. New contributors can't compile 1.9.